### PR TITLE
fixed bug where excluded namespaces still show the last approved revi…

### DIFF
--- a/action/approve.php
+++ b/action/approve.php
@@ -80,7 +80,7 @@ class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
     function handle_viewer(Doku_Event $event, $param) {
         global $REV, $ID;
         if ($event->data != 'show') return;
-        if (auth_quickaclcheck($ID) > AUTH_READ) return;
+        if (auth_quickaclcheck($ID) > AUTH_READ || ($this->hlp->in_namespace($this->getConf('no_apr_namespaces'), $ID))) return;
         
 	    $last = $this->find_lastest_approved();
 	    //no page is approved


### PR DESCRIPTION
If a page is approved at some point of time, and later on the namespace is added to the excluded namespaces, the page will only show the last approved version instead of the last edit.

In the function handle_viewer() a check is added to always get the last draft if the namespace is excluded later on.