### PR TITLE
added functionality for intermediate state 'ready for approval'

### DIFF
--- a/action/approve.php
+++ b/action/approve.php
@@ -2,6 +2,7 @@
 
 if(!defined('DOKU_INC')) die();
 define(APPROVED, 'Approved');
+define(READY_FOR_APPROVAL, 'Ready for approval');
 
 class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
 
@@ -27,6 +28,10 @@ class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
 		if ($event->data == 'diff' && isset($_GET['approve'])) {
 			ptln('<a href="'.DOKU_URL.'doku.php?id='.$_GET['id'].'&approve=approve">'.$this->getLang('approve').'</a>');
 		}
+
+		if ($event->data == 'diff' && isset($_GET['ready_for_approval'])) {
+			ptln('<a href="'.DOKU_URL.'doku.php?id='.$_GET['id'].'&ready_for_approval=ready_for_approval">'.$this->getLang('approve_ready').'</a>');
+		}
 	}
 
 	function handle_showrev(Doku_Event $event, $param) {
@@ -40,6 +45,11 @@ class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
 	function can_approve() {
 		global $ID;
 		return auth_quickaclcheck($ID) >= AUTH_DELETE;
+	}
+
+		function can_edit() {
+		global $ID;
+		return auth_quickaclcheck($ID) >= AUTH_EDIT;
 	}
 
 	function handle_approve(Doku_Event $event, $param) {
@@ -76,6 +86,36 @@ class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
 			
 			header('Location: ?id='.$ID);
 		}
+
+		if ($event->data == 'show' && isset($_GET['ready_for_approval'])) {
+		    if ( ! $this->can_edit()) return;
+		    
+			//change last commit comment to Approved
+			$meta = p_read_metadata($ID);
+			$meta[current][last_change][sum] = $meta[persistent][last_change][sum] = READY_FOR_APPROVAL;
+			$meta[current][last_change][user] = $meta[persistent][last_change][user] = $INFO[client];
+			if (!array_key_exists($INFO[client], $meta[current][contributor])) {
+			    $meta[current][contributor][$INFO[client]] = $INFO[userinfo][name];
+			    $meta[persistent][contributor][$INFO[client]] = $INFO[userinfo][name];
+			}
+			p_save_metadata($ID, $meta);
+			//update changelog
+			//remove last line from file
+			$changelog_file = metaFN($ID, '.changes');
+			$changes = file($changelog_file, FILE_SKIP_EMPTY_LINES);
+			$lastLogLine = array_pop($changes);
+			$info = parseChangelogLine($lastLogLine);
+			
+			$info[user] = $INFO[client];
+			$info[sum] = APPROVED;
+			
+			$logline = implode("\t", $info)."\n";
+			array_push($changes, $logline);
+			
+			io_saveFile($changelog_file, implode('', $changes));
+			
+			header('Location: ?id='.$ID);
+		}		
 	}
     function handle_viewer(Doku_Event $event, $param) {
         global $REV, $ID;
@@ -119,7 +159,7 @@ class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
 		
 		$sum = $this->hlp->page_sum($ID, $REV);
 
-		ptln('<div class="approval '.($sum == APPROVED ? 'approved_yes' : 'approved_no').'">');
+		ptln('<div class="approval '.($sum == APPROVED ? 'approved_yes' : ($sum == READY_FOR_APPROVAL ? 'approved_ready' :'approved_no')).'">');
 
 		tpl_pageinfo();
 		ptln(' | ');
@@ -138,6 +178,11 @@ class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
 		} else {
 			ptln('<span>'.$this->getLang('draft').'</span>');
 
+			if ($sum == READY_FOR_APPROVAL) {
+				ptln('<span>| '.$this->getLang('marked_approve_ready').'</span>');
+			}
+
+
 			if ($last_approved_rev == -1) {
 			    if ($REV != 0) {
 				    ptln('<a href="'.wl($ID).'">');
@@ -154,6 +199,13 @@ class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
 				ptln('</a>');
 			}
 
+			if ($REV == 0 && $this->can_edit() && $sum != READY_FOR_APPROVAL) {
+				ptln('<a href="'.wl($ID, array('rev' => $last_approved_rev, 'do' => 'diff',
+				'ready_for_approval' => 'ready_for_approval')).'">');
+					ptln($this->getLang('approve_ready'));
+				ptln('</a>');
+			}
+
 			//można zatwierdzać tylko najnowsze strony
 			if ($REV == 0 && $this->can_approve()) {
 				ptln('<a href="'.wl($ID, array('rev' => $last_approved_rev, 'do' => 'diff',
@@ -161,6 +213,8 @@ class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
 					ptln($this->getLang('approve'));
 				ptln('</a>');
 			}
+
+
 		}
 		ptln('</div>');
 	}

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -2,6 +2,9 @@
 
 $lang['approve'] = 'Approve';
 $lang['approved'] = 'Approved';
+$lang['approve_ready'] = 'Mark ready for approval';
+$lang['marked_approve_ready'] = 'Ready for approval';
+
 $lang['draft'] = 'Draft';
 $lang['last_approved'] = 'Last approved';
 $lang['newest_draft'] = 'Newest draft';
@@ -12,5 +15,6 @@ $lang['hdr_state'] = 'State';
 $lang['hdr_updated'] = 'Updated';
 
 $lang['all_approved'] = 'Approved';
+$lang['all_approved_ready'] = 'Ready for approval';
 
 $lang['by'] = 'by';

--- a/lang/pl/lang.php
+++ b/lang/pl/lang.php
@@ -2,6 +2,8 @@
 
 $lang['approve'] = 'Zatwierdź';
 $lang['approved'] = 'Zatwierdzona';
+$lang['approve_ready'] = 'Mark ready for approval';
+$lang['marked_approve_ready'] = 'Ready for approval';
 $lang['draft'] = 'Szkic';
 $lang['last_approved'] = 'Ostatnia zatwierdzona';
 $lang['newest_draft'] = 'Najnowszy szkic';
@@ -12,5 +14,6 @@ $lang['hdr_state'] = 'Status';
 $lang['hdr_updated'] = 'Data';
 
 $lang['all_approved'] = 'Zatwierdzone';
+$lang['all_approved_ready'] = 'Ready for approval';
 
 $lang['by'] = 'przez';

--- a/style.css
+++ b/style.css
@@ -20,6 +20,10 @@ div.approval {
   background-color: #fdd;
 }
 
+.approved_ready {
+  background-color: #b5d2f9;
+}
+
 div.approval span {
   font-weight: bold;
 }

--- a/syntax.php
+++ b/syntax.php
@@ -62,6 +62,7 @@ class syntax_plugin_approve extends DokuWiki_Syntax_Plugin {
 
 
 		$all_approved = 0;
+        $all_approved_ready = 0;
 		$all = 0;
 		
         $working_ns = null;
@@ -86,11 +87,18 @@ class syntax_plugin_approve extends DokuWiki_Syntax_Plugin {
             $class = 'approved_no';
             $state = $this->getLang('draft');
             $all += 1;
-            if ($page[1] === true) {
+
+            if ($page[1] === 'approved') {
 				$class = 'approved_yes';
 				$state = $this->getLang('approved');
 				$all_approved += 1;
 			}
+
+            if ($page[1] === 'ready for approval') {
+                $class = 'approved_ready';
+                $state = $this->getLang('marked_approve_ready');
+                $all_approved_ready += 1;
+            }
 
             $renderer->doc .= '<tr class="'.$class.'">';
             $renderer->doc .= '<td><a href="';
@@ -114,15 +122,26 @@ class syntax_plugin_approve extends DokuWiki_Syntax_Plugin {
             $renderer->doc .= $updated;
             $renderer->doc .= '</td></tr>';
         }
+
+        $renderer->doc .= '<tr><td><strong>';
+        $renderer->doc .= $this->getLang('all_approved_ready');
+        $renderer->doc .= '</strong></td>';
+        
+        $renderer->doc .= '<td colspan="2">';
+        $renderer->doc .= $all_approved_ready.' / '.$all . sprintf(" (%.0f%%)", $all_approved_ready*100/$all);
+        $renderer->doc .= '</td></tr>';
+        
         $renderer->doc .= '<tr><td><strong>';
         $renderer->doc .= $this->getLang('all_approved');
         $renderer->doc .= '</strong></td>';
         
         $renderer->doc .= '<td colspan="2">';
         $renderer->doc .= $all_approved.' / '.$all . sprintf(" (%.0f%%)", $all_approved*100/$all);
-        $renderer->doc .= '</td>';
-        
-        $renderer->doc .= '</tr></table>';
+        $renderer->doc .= '</td></tr>';
+ 
+
+
+        $renderer->doc .= '</table>';
         return true;
     }
     
@@ -149,10 +168,12 @@ class syntax_plugin_approve extends DokuWiki_Syntax_Plugin {
 		//var_dump($meta);
 		$date = $meta['date']['modified'];
 		if (isset($meta['last_change']) && $meta['last_change']['sum'] === 'Approved') {
-			$approved = true;
+			$approved = 'approved';
+		} elseif (isset($meta['last_change']) && $meta['last_change']['sum'] === 'Ready for approval') {
+			$approved = 'ready for approval';
 		} else {
-			$approved = false;
-		}
+            $approved = 'not approved';
+        }
 
 		if (isset($meta['last_change'])) {
 			$user = $meta['last_change']['user'];


### PR DESCRIPTION
At the moment a page status is either 'draft' or 'approved'. For general usage it is convenient to have a intermediate stage 'ready for approval', to let other people (reviewers) know that a page is ready to be checked and approved.

The added functionality:
- Added 'ready for approve' link when in newest draft
- Blue color for approve bar when marked 'ready for approval'
- Blue color in approval overview table and text 'ready for approval', to get an overview of the page(s) which have to be checked by the owner(s) (permission auth_delete) and approved
- Marking a page 'ready for approval' can be done by anybody with edit permissions or higher
- Owner (auth_delete) can still approve a page immediately, or mark the page 'ready for approval' if somebody else has to check the page first.



