### PR TITLE
Added support for MS Windows environments by replacing path delimiter…

### DIFF
--- a/action/migration.php
+++ b/action/migration.php
@@ -83,6 +83,7 @@ class action_plugin_approve_migration extends DokuWiki_Action_Plugin
             //remove start path and extension
             $page = substr($file->getPathname(), strlen($datadir), -4);
             $pages[] = str_replace('/', ':', $page);
+			$pages[] = str_replace('\\', ':', $page);
         }
 
         $db->beginTransaction();

--- a/admin.php
+++ b/admin.php
@@ -39,6 +39,7 @@ class admin_plugin_approve extends DokuWiki_Admin_Plugin
             $path = $fileinfo->getPathname();
             //remove .txt
             $id = str_replace('/', ':', substr($path, strlen($datadir), -4));
+            $id = str_replace('\\', ':', substr($path, strlen($datadir), -4));
             $pages[] = $id;
         }
 


### PR DESCRIPTION
… / AND \.

This is a possible solution for #22 as I had the same problem using dokuwiki on a stick on a MS Windows host.

All entries in the sqlite-db have to be corrected manually or the tables have to be rebuilt.