### PR TITLE
Added configuration items, translations

### DIFF
--- a/action/approve.php
+++ b/action/approve.php
@@ -180,7 +180,7 @@ class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
 		global $INFO;
 
 		/* Return true if banner should not be displayed for users with or below read only permission. */
-		if($this->getConf('hide_banner_for_readonly') && auth_quickaclcheck($ID) <= AUTH_READ) {
+		if(auth_quickaclcheck($ID) <= AUTH_READ && !$this->getConf('display_banner_for_readonly')) {
 			return true;
 		};
 		

--- a/action/approve.php
+++ b/action/approve.php
@@ -179,6 +179,13 @@ class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
     public function handle_display_banner(Doku_Event $event) {
 		global $INFO;
 
+		/* Return true if banner should not be displayed for users with or below read only permission. */
+		if($this->getConf('hide_banner_for_readonly') && auth_quickaclcheck($ID) <= AUTH_READ) {
+			return true;
+		};
+		
+
+		/* Not returned - rendering the banner */
         try {
             /** @var \helper_plugin_approve_db $db_helper */
             $db_helper = plugin_load('helper', 'approve_db');
@@ -227,8 +234,11 @@ class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
 		if ($approve['approved']) {
 			ptln('<strong>'.$this->getLang('approved').'</strong>');
             ptln(' ' . dformat(strtotime($approve['approved'])));
-            ptln(' ' . $this->getLang('by') . ' ' . userlink($approve['approved_by'], true));
-            ptln(' (' . $this->getLang('version') .  ': ' . $approve['version'] . ')');
+			
+			if($this->getConf('banner_long')) {
+				ptln(' ' . $this->getLang('by') . ' ' . userlink($approve['approved_by'], true));
+				ptln(' (' . $this->getLang('version') .  ': ' . $approve['version'] . ')');
+			}
 
 			//not the newest page
 			if ($rev != $last_change_date) {
@@ -327,7 +337,7 @@ class action_plugin_approve_approve extends DokuWiki_Action_Plugin {
             }
 		}
 
-		if ($approver) {
+		if ($approver && $this->getConf('banner_long')) {
             ptln(' | ' . $this->getLang('approver') . ': ' . userlink($approver, true));
         }
 

--- a/conf/default.php
+++ b/conf/default.php
@@ -10,5 +10,5 @@ $conf['sum draft'] = 'Draft';
 $conf['strict_approver'] = 1;
 $conf['hide_drafts_for_viewers'] = 1;
 
-$conf['hide_banner_for_readonly'] = 0;
+$conf['display_banner_for_readonly'] = 1;
 $conf['banner_long'] = 1;

--- a/conf/default.php
+++ b/conf/default.php
@@ -9,3 +9,6 @@ $conf['sum ready for approval'] = 'Ready for approval';
 $conf['sum draft'] = 'Draft';
 $conf['strict_approver'] = 1;
 $conf['hide_drafts_for_viewers'] = 1;
+
+$conf['hide_banner_for_readonly'] = 0;
+$conf['banner_long'] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -2,7 +2,7 @@
 $meta['no_apr_namespaces'] = array('string');
 $meta['prettyprint'] = array('onoff');
 $meta['ready_for_approval'] = array('onoff');
-$meta['hide_banner_for_readonly'] = array('onoff');
+$meta['display_banner_for_readonly'] = array('onoff');
 $meta['banner_long'] = array('onoff');
 $meta['strict_approver'] = array('onoff', '_caution' => 'security');
 $meta['hide_drafts_for_viewers'] = array('onoff', '_caution' => 'security');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -2,5 +2,7 @@
 $meta['no_apr_namespaces'] = array('string');
 $meta['prettyprint'] = array('onoff');
 $meta['ready_for_approval'] = array('onoff');
+$meta['hide_banner_for_readonly'] = array('onoff');
+$meta['banner_long'] = array('onoff');
 $meta['strict_approver'] = array('onoff', '_caution' => 'security');
 $meta['hide_drafts_for_viewers'] = array('onoff', '_caution' => 'security');

--- a/lang/de/assignments_intro.txt
+++ b/lang/de/assignments_intro.txt
@@ -1,0 +1,8 @@
+========= Genehmigungen zuordnen ========
+
+Hier können Sie Seiten/Namensräume definieren, auf denen das Approve-Plugin verwendet wird, und deren Genehmigende angeben.
+Eine präzisere Regel überlagert die allgemeinere.
+
+  * Namensräume ohne Unter-Namensräume werden als ''<nowiki>namespace:*</nowiki>'' zugewiesen.
+  * Namensräume, die Unter-Namensräume einschließen, werden als ''<nowiki>namespace:**</nowiki>'' zugewiesen.
+  * Seiten werden wie üblich mit ihrer vollständigen Seiten-ID angegeben.

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -1,8 +1,14 @@
 <?php
 
 $lang['approve'] = 'freigeben';
-$lang['approved'] = 'Freigabe';
+$lang['approved'] = 'Geprüft';
+$lang['version'] = 'Version';
+$lang['approver'] = 'Genehmiger';
+
 $lang['draft'] = 'Entwurf';
+$lang['approve_ready'] = 'Als freizugeben markieren';
+$lang['marked_approve_ready'] = 'Fertig zur Freigabe';
+
 $lang['last_approved'] = 'zuletzt geprüft';
 $lang['newest_draft'] = ' -> Neuester Entwurf';
 $lang['newest_approved'] = ' -> Aktuelle Freigabe';
@@ -10,7 +16,18 @@ $lang['newest_approved'] = ' -> Aktuelle Freigabe';
 $lang['hdr_page'] = 'Seite';
 $lang['hdr_state'] = 'Status';
 $lang['hdr_updated'] = 'Aktualisierung';
+$lang['hdr_approver'] = $lang['approver'];
 
 $lang['all_approved'] = 'Freigaben insgesamt';
 
 $lang['by'] = 'von';
+
+// menu entry for admin plugins
+$lang['menu'] = 'Genehmiger zuordnen (Approve)';
+
+$lang['admin btn_delete'] = 'Löschen';
+$lang['admin btn_add'] = 'Hinzufügen';
+$lang['admin h_assignment_namespace'] = 'Seite/Namensraum';
+$lang['admin h_assignment_approver'] = $lang['approver'];
+
+$lang['notification full'] = 'Sie können folgende Seite freigeben: %s';

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -4,5 +4,5 @@ $lang['prettyprint'] = 'Ausdruck mit schöner Überschrift';
 $lang['ready_for_approval'] = 'Zwischenstatus "Fertig zur Freigabe" aktivieren.';
 $lang['strict_approver'] = 'Nur Freigabeberechtigte können ihre Seiten freigeben (ausschließlich).';
 $lang['hide_drafts_for_viewers'] = 'Verstecke Entwürfe vor Benutzern ohne Bearbeitungsrecht und zeige die letzte freigegebene Version stattdessen..';
-$lang['hide_banner_for_readonly'] = 'Banner verstecken für ReadOnly-Benutzer';
+$lang['display_banner_for_readonly'] = 'Banner anzeigen für ReadOnly-Benutzer';
 $lang['banner_long'] = 'Langes Banner (mit Versionsnummer und Freigebendem)';

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -1,3 +1,8 @@
 <?php
 $lang['no_apr_namespaces'] = 'Namensräume, wo dieses Plugin <strong>NICHT</strong> gelten soll (mehrere mit Leerzeichen separieren)';
 $lang['prettyprint'] = 'Ausdruck mit schöner Überschrift';
+$lang['ready_for_approval'] = 'Zwischenstatus "Fertig zur Freigabe" aktivieren.';
+$lang['strict_approver'] = 'Nur Freigabeberechtigte können ihre Seiten freigeben (ausschließlich).';
+$lang['hide_drafts_for_viewers'] = 'Verstecke Entwürfe vor Benutzern ohne Bearbeitungsrecht und zeige die letzte freigegebene Version stattdessen..';
+$lang['hide_banner_for_readonly'] = 'Banner verstecken für ReadOnly-Benutzer';
+$lang['banner_long'] = 'Langes Banner (mit Versionsnummer und Freigebendem)';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -4,3 +4,5 @@ $lang['prettyprint'] = 'Use pretty headings on print.';
 $lang['ready_for_approval'] = 'Enable intermediate state "mark ready for approval" to let a reviewer know the page can be checked/approved';
 $lang['strict_approver'] = 'Only approvers can approve their pages.';
 $lang['hide_drafts_for_viewers'] = 'Hide draft from users without edit permission and show the latest approved revision instead.';
+$lang['hide_banner_for_readonly'] = 'Hide banner for users with AUTH_READ only.';
+$lang['banner_long'] = 'Long banner including version number and approver';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -4,5 +4,5 @@ $lang['prettyprint'] = 'Use pretty headings on print.';
 $lang['ready_for_approval'] = 'Enable intermediate state "mark ready for approval" to let a reviewer know the page can be checked/approved';
 $lang['strict_approver'] = 'Only approvers can approve their pages.';
 $lang['hide_drafts_for_viewers'] = 'Hide draft from users without edit permission and show the latest approved revision instead.';
-$lang['hide_banner_for_readonly'] = 'Hide banner for users with AUTH_READ only.';
+$lang['display_banner_for_readonly'] = 'Display banner for users with AUTH_READ only.';
 $lang['banner_long'] = 'Long banner including version number and approver';


### PR DESCRIPTION
Hi,

I added configuration items for a shorter banner (approved versions only) and hiding the banner completely for users having read only permissions.

I hope, the return true in approve.php:182++ is a correct way and does not imply security considerations - I've seen the logic for handling the option "hide_drafts_for_viewers" is being done in another part and only the displaying part is being touched by my changes.

I also changed and added some translations in german language files. It's kind of a detail discussion to call something "Geprüft" or "Freigegeben" in german language and the wording to be used is defined by the individual process of approving.

Regards
Martin