### PR TITLE
Remove escape character from table query

### DIFF
--- a/syntax/table.php
+++ b/syntax/table.php
@@ -172,7 +172,7 @@ class syntax_plugin_approve_table extends DokuWiki_Syntax_Plugin {
                     revision.ready_for_approval, revision.ready_for_approval_by,
                     LENGTH(page.page) - LENGTH(REPLACE(page.page, ':', '')) AS colons
                     FROM page INNER JOIN revision ON page.page = revision.page
-                    WHERE page.hidden = 0 AND revision.current=1 AND page.page LIKE ? ESCAPE '_'
+                    WHERE page.hidden = 0 AND revision.current=1 AND page.page LIKE ?
                             $approver_query
                     ORDER BY colons, page.page";
 


### PR DESCRIPTION
On some of our systems the table query returns no rows. When we execute the select query outside of PHP context, or without the `ESCAPE` definition, the result is as expected. This PR simply removes it from the query and ensures compatibility with more PHP/SQLite setups.

From what I see you do not really need to define the escape character at this point. Or am I missing something?