### PR TITLE
Add remote API support

### DIFF
--- a/PageRemoteResponse.php
+++ b/PageRemoteResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace dokuwiki\plugin\approve;
+
+use dokuwiki\Remote\Response\Page;
+
+/**
+ * Represents a page to return as result in the remote API
+ */
+class PageRemoteResponse extends Page
+{
+    /** @var string User or Group assigned to approve this page */
+    public $approver;
+
+    /** @var string The current state of approval: draft, ready_for_approval, approved */
+    public $status;
+
+    /** @var int Timestamp of approval, 0 if not approved */
+    public $approved;
+
+    /** @var int Timestamp of ready for approval, 0 if not ready */
+    public $ready_for_approval;
+
+    /** @var string User who approved this page, empty if not approved */
+    public $approved_by;
+
+    /** @var string User who marked this page as ready for approval, empty if not ready */
+    public $ready_for_approval_by;
+
+    /** @var string not returned by this endpoint - will always be empty */
+    public $author = '';
+
+    /** @var string not returned by this endpoint - will always be empty */
+    public $hash = '';
+
+
+    /**
+     * @param array $data The data as returned by helper_db::getPages
+     */
+    public function __construct($data)
+    {
+        parent::__construct(
+            $data['id'],
+            $data['rev'],
+        );
+
+        $this->approver = $data['approver'];
+        $this->status = $data['status'];
+
+        $this->approved = $data['approved'] ? strtotime($data['approved']) : 0;
+        $this->ready_for_approval = $data['ready_for_approval'] ? strtotime($data['ready_for_approval']) : 0;
+
+        $this->approved_by = (string)$data['approved_by'];
+        $this->ready_for_approval_by = (string)$data['ready_for_approval_by'];
+    }
+}

--- a/remote.php
+++ b/remote.php
@@ -1,0 +1,102 @@
+<?php
+
+use dokuwiki\Extension\RemotePlugin;
+use dokuwiki\plugin\approve\PageRemoteResponse;
+use dokuwiki\Remote\RemoteException;
+
+/**
+ * DokuWiki Plugin approve (Action Component)
+ *
+ * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
+ * @author Andreas Gohr <dokuwiki@cosmocode.de>
+ */
+class remote_plugin_approve extends RemotePlugin
+{
+
+    /**
+     * Get wiki pages and their approval status
+     *
+     * Return all pages that are under control of the approval plugin, optionally filtered.
+     *
+     * @param string[] $states Return only pages matchin this state [approved, draft, ready_for_approval]
+     * @param string $namespace Only return pages within this namespace, empty for all
+     * @param string $filter Only return pages matching this regex, empty for all
+     * @param string $approver Only return pages to be approved by this user or group, empty for all
+     * @return PageRemoteResponse[]
+     * @throws RemoteException
+     */
+    public function getPages(
+        $states = ['approved', 'draft', 'ready_for_approval'], $namespace = '', $filter = '', $approver = ''
+    )
+    {
+        global $auth;
+
+        if (array_diff($states, ['approved', 'draft', 'ready_for_approval'])) {
+            throw new RemoteException('Invalid state(s) provided', 122);
+        }
+
+        $namespace = cleanID($namespace);
+
+        if (@preg_match('/' . $filter . '/', null) === false) {
+            throw new RemoteException('Invalid filter regex', 123);
+        }
+
+        $approver = $auth->cleanUser($approver);
+
+        /** @var helper_plugin_approve_db $db */
+        $db = plugin_load('helper', 'approve_db');
+        $pages = $db->getPages($approver, $states, $namespace, $filter);
+
+        return array_map(function ($data) {
+            return new PageRemoteResponse($data);
+        }, $pages);
+    }
+
+    /**
+     * Set the approval status of a page
+     *
+     * Mark a given page as approved or ready for approval
+     *
+     * @param string $page The page id
+     * @param string $status The new status [approved, ready_for_approval]
+     * @return true
+     * @throws RemoteException
+     */
+    public function setStatus($page, $status)
+    {
+        /** @var helper_plugin_approve_acl $acl */
+        $acl = plugin_load('helper', 'approve_acl');
+
+        /** @var helper_plugin_approve_db $db */
+        $db = plugin_load('helper', 'approve_db');
+
+        if (!page_exists($page)) {
+            throw new RemoteException('Page does not exist', 121);
+        }
+
+        if (!$acl->useApproveHere($page)) {
+            throw new RemoteException('This page is not under control of the approve plugin', 124);
+        }
+
+        global $INFO;
+        global $USERINFO;
+        $INFO['userinfo'] = $USERINFO;
+
+        if ($status == 'approved') {
+            if (!$acl->clientCanApprove($page)) {
+                throw new RemoteException('You are not allowed to approve this page', 111);
+            }
+            $db->setApprovedStatus($page);
+        } elseif ($status == 'ready_for_approval') {
+            if (!$acl->clientCanMarkReadyForApproval($page)) {
+                throw new RemoteException('You are not allowed to mark this page as ready for approval', 111);
+            }
+            $db->setReadyForApprovalStatus($page);
+        } else {
+            throw new RemoteException('Invalid status', 122);
+
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
This adds a remote API component to the plugin. It provides two endpoints:

getPages - an equivalent to the approve table syntax. It allows to list pages needing approval, etc.

setStatus - allows to approve pages or mark them as ready for approval.

Use the APIExplorer to see the complete documentation.